### PR TITLE
Remove duplicate driver in test_correct_db_type_from_uri

### DIFF
--- a/tests/store/test_sqlalchemy_store.py
+++ b/tests/store/test_sqlalchemy_store.py
@@ -42,7 +42,7 @@ class TestParseDbUri(unittest.TestCase):
             'postgresql': ('psycopg2', 'pg8000', 'psycopg2cffi',
                            'pypostgresql', 'pygresql', 'zxjdbc'),
             'mysql': ('mysqldb', 'pymysql', 'mysqlconnector', 'cymysql',
-                      'oursql', 'mysqldb', 'gaerdbms', 'pyodbc', 'zxjdbc'),
+                      'oursql', 'gaerdbms', 'pyodbc', 'zxjdbc'),
             'mssql': ('pyodbc', 'mxodbc', 'pymssql', 'zxjdbc', 'adodbapi')
         }
         for target_db_type, drivers in target_db_type_uris.items():


### PR DESCRIPTION
## What changes are proposed in this pull request?
There are two **mysqldb** in test_correct_db_type_from_uri, we should only have one
 
## How is this patch tested?
 
(Details)
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [x] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [x] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
